### PR TITLE
Bump Java version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:8
+FROM openjdk:16
 COPY /target/prophet-app-utils-0.0.1-SNAPSHOT.jar app.jar
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 	</properties>
  -->
  	<properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
     </properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
One of multiple PRs for the refactoring done while adding an HTTP API for bounded-context. Bumps the Java version to work with the other updated libraries.

Other PRs to this end:
https://github.com/cloudhubs/prophet-dto/pull/12
https://github.com/cloudhubs/bounded-context/pull/6